### PR TITLE
Add MediatR and FluentValidation.DependencyInjectionExtensions

### DIFF
--- a/src/RS.Application/DependencyInjection.cs
+++ b/src/RS.Application/DependencyInjection.cs
@@ -1,0 +1,24 @@
+﻿namespace RS.Application;
+
+#region Usings
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using FluentValidation;
+#endregion
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        Assembly assembly = typeof(DependencyInjection).Assembly;
+
+        services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblies(assembly));
+
+        services.AddValidatorsFromAssembly(assembly);
+
+        return services;
+    }
+}
+

--- a/src/RS.Application/RS.Application.csproj
+++ b/src/RS.Application/RS.Application.csproj
@@ -6,4 +6,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RS.Domain\RS.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/RS.Infrastructure/DependencyInjection.cs
+++ b/src/RS.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,11 @@
+﻿namespace RS.Infrastructure;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        return services;
+    }
+}

--- a/src/RS.Infrastructure/RS.Infrastructure.csproj
+++ b/src/RS.Infrastructure/RS.Infrastructure.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/RS.WebAPI/Program.cs
+++ b/src/RS.WebAPI/Program.cs
@@ -1,15 +1,18 @@
+using RS.Application;
+using RS.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services
+    .AddApplication()
+    .AddInfrastructure();
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/src/RS.WebAPI/RS.WebAPI.csproj
+++ b/src/RS.WebAPI/RS.WebAPI.csproj
@@ -15,4 +15,9 @@
     <Folder Include="Controllers\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\RS.Application\RS.Application.csproj" />
+    <ProjectReference Include="..\RS.Infrastructure\RS.Infrastructure.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Add MediatR
MediatR is a NuGet package for . NET applications that helps to implement the Mediator pattern and MediatR can be used as a useful tool to implement CQRS in a . NET application. MediatR pattern helps to reduce direct dependency between multiple objects and make them collaborative through MediatR.

Add FluentValidation.DependencyInjectionExtensions
NET validation library FluentValidation - The extension enables the use of dependency injection to manage the creation and disposal of validator instances, which can be useful for managing a large number of validators or injecting dependencies into validators
